### PR TITLE
Add support for Rocky Linux

### DIFF
--- a/tasks/main-tasks.yml
+++ b/tasks/main-tasks.yml
@@ -1,8 +1,8 @@
-- name: CentOS - Install EPEL repo
+- name: CentOS or Rocky - Install EPEL repo
   package:
    name: epel-release
    state: present
-  when: ansible_distribution == 'CentOS'
+  when: (ansible_distribution == 'CentOS') or (ansible_distribution == 'Rocky')
 
 # On debian, installing the etckeeper package seems to put /etc
 # under version control immediately.

--- a/tasks/main-tasks.yml
+++ b/tasks/main-tasks.yml
@@ -1,3 +1,8 @@
+# For RockyLinux, also need to enable the Powertools repo with "dnf
+# config-manager --set-enabled powertools".
+# etckeeper do not seem to need anything from the Powertools repo but keep
+# that in mind for proper EPEL repo activation, per
+# https://docs.fedoraproject.org/en-US/epel/#_quickstart
 - name: CentOS or Rocky - Install EPEL repo
   package:
    name: epel-release


### PR DESCRIPTION
Rocky Linux is the successor to the CentOS project.

"On December 8, 2020, Red Hat announced that they would discontinue development of CentOS, which has been a production-ready downstream version of Red Hat Enterprise Linux, in favor of a newer upstream development variant of that operating system known as "CentOS Stream". In response, original founder of CentOS, Gregory Kurtzer, announced [via a comment on the CentOS website](https://blog.centos.org/2020/12/future-is-centos-stream/#comment-183642) that he would again start a project to achieve the original goals of CentOS. It's name was chosen as a tribute to early CentOS co-founder Rocky McGaugh. By December 12, the code repository of Rocky Linux had become the top-trending repository on GitHub.", from https://rockylinux.org/about